### PR TITLE
HEVO-7016: Support for custom expiry times for Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ scheduler.stop()
       <dependency>
           <groupId>com.hevodata</groupId>
           <artifactId>simple-scheduler_2.11</artifactId>
-          <version>0.1.5</version>
+          <version>0.1.6</version>
       </dependency>
           
   </code>

--- a/src/main/scala/com/hevodata/scheduler/Job.scala
+++ b/src/main/scala/com/hevodata/scheduler/Job.scala
@@ -1,5 +1,6 @@
 package com.hevodata.scheduler
 
+import com.hevodata.scheduler.core.Constants
 import com.hevodata.scheduler.dto.ExecutionContext
 
 /**
@@ -7,6 +8,14 @@ import com.hevodata.scheduler.dto.ExecutionContext
  */
 trait Job {
   def execute(context: ExecutionContext): ExecutionStatus.Status
+
+  /**
+   * An approximation on what the max run time of this job should be kept as.
+   * This number is just for assuming we have lost contact with the executor and are going to mark the task as Expired after this much time has lapsed.
+   * The execution should typically be in seconds.
+   * (In seconds)
+   */
+  def maxRunTime(): Long = Constants.MaxRunTime
 }
 
 /**

--- a/src/main/scala/com/hevodata/scheduler/Scheduler.scala
+++ b/src/main/scala/com/hevodata/scheduler/Scheduler.scala
@@ -20,7 +20,7 @@ class Scheduler private {
   private var config: SchedulerConfig = _
   private var monitor: ScheduledExecutorService = _
 
-  private var schedulerService: SchedulerService = _
+  var schedulerService: SchedulerService = _
   var schedulerRegistry: SchedulerRegistry = _
 
   def this(config: SchedulerConfig, jobHandlerFactory: JobHandlerFactory = new ConstructionBasedFactory) {

--- a/src/main/scala/com/hevodata/scheduler/config/WorkConfig.scala
+++ b/src/main/scala/com/hevodata/scheduler/config/WorkConfig.scala
@@ -32,7 +32,7 @@ class WorkConfig(_appId: String) {
   /**
    * Attempt cleanup of "stuck" objects proactively at this frequency (in seconds)
    */
-  var cleanupFrequency: Int = 45 * 60
+  var cleanupFrequency: Int = 5 * 60
 
   var logFailures: Boolean = true
 
@@ -43,6 +43,11 @@ class WorkConfig(_appId: String) {
    * If true, the next execution is in reference to the current execution completion instant
    */
   var nextRelativeToNow: Boolean = false
+
+  def cleanupFrequency(cleanupFrequency: Int): WorkConfig = {
+    this.cleanupFrequency = cleanupFrequency
+    this
+  }
 
   def workers(workers: Int): WorkConfig = {
     this.workers = workers

--- a/src/main/scala/com/hevodata/scheduler/core/Constants.scala
+++ b/src/main/scala/com/hevodata/scheduler/core/Constants.scala
@@ -17,6 +17,7 @@ object Constants {
   val fieldScheduleExpression: String = "schedule_expression"
   val fieldExecutorId: String = "executor_id"
 
+  val fieldPickedTime: String = "picked_at"
   val fieldExecutionTime: String = "execution_time"
   val fieldNextExecutionTime: String = "next_execution_time"
 
@@ -28,5 +29,7 @@ object Constants {
 
   val DefaultNamespace = "DEFAULT"
 
+  // In seconds
   val InitialDelay: Long = 5
+  val MaxRunTime: Long = 45 * 60
 }

--- a/src/main/scala/com/hevodata/scheduler/core/model/TaskDetails.scala
+++ b/src/main/scala/com/hevodata/scheduler/core/model/TaskDetails.scala
@@ -13,6 +13,7 @@ abstract class TaskDetails(_nameSpace: String, _key: String, _scheduleExpression
   val key: String = _key
   val scheduleExpression: String = _scheduleExpression
 
+  var pickedTime: Date = _
   var executionTime: Date = _
   var nextExecutionTime: Date = new Date
 

--- a/src/test/java/com/hevodata/scheduler/TestScheduler.java
+++ b/src/test/java/com/hevodata/scheduler/TestScheduler.java
@@ -11,18 +11,21 @@ import com.hevodata.scheduler.helpers.MySqlHelper;
 import com.hevodata.scheduler.helpers.profile.EmbeddedMySql;
 import com.hevodata.scheduler.jobs.SampleInstantaneousJob;
 import com.hevodata.scheduler.jobs.SampleLongRunningJob;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.runners.MethodSorters;
 import scala.collection.Iterator;
+import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.concurrent.duration.Duration;
 
 import javax.sql.DataSource;
-import java.util.HashMap;
-import java.util.Map;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestScheduler {
 
     private static final String TABLE_PREFIX = "mysql_";
@@ -50,7 +53,7 @@ public class TestScheduler {
     }
 
     @Test
-    public void test() throws Exception {
+    public void test1TaskLifeCycle() throws Exception {
         WorkConfig workConfig = new WorkConfig("host_name_1").logFailures(true).shutDownWait(3);
         // Lock lock = RedisLockProvider.createLock("localhost", 6379);
         SchedulerConfig schedulerConfig = new SchedulerConfig(dataSource, workConfig).withTablePrefix(TABLE_PREFIX).withPollFrequency(2); //.withLock(lock);
@@ -86,6 +89,56 @@ public class TestScheduler {
         Assert.assertEquals(TaskStatus.FAILED(), map.get("FAIL_IMMEDIATELY").status());
         Assert.assertEquals(3, map.get("Cron-1").executions());
         Assert.assertEquals(TaskStatus.SUCCEEDED(), map.get("Cron-1").status());
+    }
+
+    @Test
+    public void test2TaskExpiry() throws Exception {
+        WorkConfig workConfig = new WorkConfig("host_name_1").logFailures(true).shutDownWait(3).cleanupFrequency(-2);
+        SchedulerConfig schedulerConfig = new SchedulerConfig(dataSource, workConfig).withTablePrefix(TABLE_PREFIX).withPollFrequency(2);
+        Scheduler scheduler = new Scheduler(schedulerConfig, jobResolver);
+        scheduler.schedulerRegistry().register(new RepeatableTask(NS, "Short-1", Duration.apply(300, TimeUnit.SECONDS), JOB_INSTANTANEOUS_FQCN));
+        scheduler.schedulerRegistry().register(new CronTask(NS, "Short-2", "0/6 * * * * ?", JOB_INSTANTANEOUS_FQCN));
+        scheduler.schedulerRegistry().register(new CronTask(NS, "Short-3", "0/3 * * * * ?", JOB_INSTANTANEOUS_FQCN));
+        scheduler.schedulerRegistry().register(new CronTask(NS, "Long-Running-2", "0/6 * * * * ?", JOB_LONG_RUNNING_FQCN));
+        scheduler.schedulerRegistry().register(new CronTask(NS, "Long-Running-3", "0/6 * * * * ?", JOB_LONG_RUNNING_FQCN));
+
+        scala.collection.Map<String, TaskDetails> map = taskRepository.get(NS,
+            JavaConversions.asScalaBuffer(Arrays.asList("Short-1", "Short-2", "Short-3", "Long-Running-2", "Long-Running-3")
+        ).toList());
+        List<Object> ids = new ArrayList<>();
+        Iterator<TaskDetails> iterator = map.valuesIterator();
+        while (iterator.hasNext()) {
+            ids.add(iterator.next().id());
+        }
+        taskRepository.markPicked(JavaConverters.asScalaBufferConverter(ids).asScala().toList(), "host_name_1");
+
+        preparePickedTask(map.get("Short-1").get().id(), 70);    // Will be marked as expired (limit 60)
+        preparePickedTask(map.get("Short-2").get().id(), 100);   // Will be marked as expired (limit 60)
+        preparePickedTask(map.get("Short-3").get().id(), 20);    // Will stay in picked (limit 60)
+        preparePickedTask(map.get("Long-Running-2").get().id(), 110 * 60);  // Will be marked as expired (limit 100*60)
+        preparePickedTask(map.get("Long-Running-3").get().id(), 45 * 60);   // Will stay in picked (limit 100*60)
+
+        scheduler.schedulerService().attemptCleanup();
+
+        map = taskRepository.get(NS,
+            JavaConversions.asScalaBuffer(Arrays.asList("Short-1", "Short-2", "Short-3", "Long-Running-2", "Long-Running-3")
+        ).toList());
+
+        Assert.assertEquals(0, TaskStatus.EXPIRED().compare(map.get("Short-1").get().status()));
+        Assert.assertEquals(0, TaskStatus.EXPIRED().compare(map.get("Short-2").get().status()));
+        Assert.assertEquals(0, TaskStatus.PICKED().compare(map.get("Short-3").get().status()));
+        Assert.assertEquals(0, TaskStatus.EXPIRED().compare(map.get("Long-Running-2").get().status()));
+        Assert.assertEquals(0, TaskStatus.PICKED().compare(map.get("Long-Running-3").get().status()));
+        scheduler.stop();
+    }
+
+    private void preparePickedTask(long taskId, int pickedInPastSeconds) throws SQLException {
+        try(Connection connection = dataSource.getConnection()) {
+            String sql = String.format("UPDATE %sscheduled_tasks set status = 'PICKED', picked_at = DATE_ADD(NOW(), INTERVAL -%d SECOND) WHERE id = %d", TABLE_PREFIX, pickedInPastSeconds, taskId);
+            try(PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.execute();
+            }
+        }
     }
 
     @AfterClass

--- a/src/test/java/com/hevodata/scheduler/jobs/SampleInstantaneousJob.java
+++ b/src/test/java/com/hevodata/scheduler/jobs/SampleInstantaneousJob.java
@@ -12,4 +12,9 @@ public class SampleInstantaneousJob implements Job {
 
         return ExecutionStatus.FAILED();
     }
+
+    @Override
+    public long maxRunTime() {
+        return 60;
+    }
 }

--- a/src/test/java/com/hevodata/scheduler/jobs/SampleLongRunningJob.java
+++ b/src/test/java/com/hevodata/scheduler/jobs/SampleLongRunningJob.java
@@ -24,4 +24,9 @@ public class SampleLongRunningJob implements Job {
         }
         return ExecutionStatus.SUCCEEDED();
     }
+
+    @Override
+    public long maxRunTime() {
+        return 100 * 60;
+    }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.5"
+version in ThisBuild := "0.1.6"


### PR DESCRIPTION
Cleanup will be attempted every 5 minutes. Each time, jobs eligible to be marked expired will be fetched (Assuming that they have somehow lost contact with the scheduler).

Eligibility for marking as expired:
- Must have run for at least 10 minutes
- Would have run for at least `minRunTime()` amount of time configured as per the `Job` (default = 45 minutes)