### PR TITLE
Upgrade version for statsd

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ releaseProcess := Seq[ReleaseStep](
 )
 
 libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.5",
+  "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.slf4j" % "slf4j-simple" % "1.7.5",
   "com.cronutils" % "cron-utils" % "5.0.5",
   "redis.clients" % "jedis" % "2.9.0",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.6"
+ThisBuild / version := "0.1.7"


### PR DESCRIPTION
Reducing log version as it is failing greenseer tests. In services also slf4j-api version 1.7.25 is used.